### PR TITLE
Return gzip writer back to pool when everything is flushed only

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/ugorji/go/codec v1.1.7 // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
-	golang.org/x/sys v0.0.0-20200116001909-b77594299b42 // indirect
+	golang.org/x/sys v0.0.0-20221010170243-090e33056c14 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20221010170243-090e33056c14 h1:k5II8e6QD8mITdi+okbbmR/cIyEbeXLBhy5Ha4nevyc=
+golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/gzip.go
+++ b/gzip.go
@@ -18,13 +18,7 @@ func Gzip(level int, options ...Option) gin.HandlerFunc {
 
 type gzipWriter struct {
 	gin.ResponseWriter
-	writer  *gzip.Writer
-	onFlush func()
-}
-
-func (g *gzipWriter) Flush() {
-	g.ResponseWriter.Flush()
-	g.onFlush()
+	writer *gzip.Writer
 }
 
 func (g *gzipWriter) WriteString(s string) (int, error) {

--- a/gzip.go
+++ b/gzip.go
@@ -18,7 +18,13 @@ func Gzip(level int, options ...Option) gin.HandlerFunc {
 
 type gzipWriter struct {
 	gin.ResponseWriter
-	writer *gzip.Writer
+	writer  *gzip.Writer
+	onFlush func()
+}
+
+func (g *gzipWriter) Flush() {
+	g.ResponseWriter.Flush()
+	g.onFlush()
 }
 
 func (g *gzipWriter) WriteString(s string) (int, error) {


### PR DESCRIPTION
## Context

The handler uses a [pool of gzip writers](https://github.com/remerge/gzip/blob/9c6d50f795839892829bc6a8d4db59c6fe3e325a/handler.go#L48). Once it is ready, the writer [is returned](https://github.com/remerge/gzip/blob/9c6d50f795839892829bc6a8d4db59c6fe3e325a/handler.go#L49) back to the pool.

## Issue

`gzipHandler` overwrites `c.Writer` with its own implementation containing `gzip.Writer` from the pool. When this function completes, it will put the writer back in the pool, which can be reused when servicing the next request.

## Solution

UPD: the solution below didn't work. `Flush()` is called for streamed requests only; not our case.
The fix was reworked to put the writer back to the pool when request is done (or, in to be on a safe side, on timeout) or client disconnected.
I struggled to write a unit test properly which reflects the real world: as a client we have no control of `http.Request` lifecycle. The worst possible scenario that the writers would be put back to the pool not immediately but once a deadline is met.

~Since we're limited the current architecture, there should be an approach when a writer is returned back to the pool only and only when the writer is done. Currently there is no standard seam to introduce such behavior.~

~The PR introduces a `flush` hook to gzip's writer, which is dispatched on http's `Flush()` is triggered. Here we can assume that everything is prepared by every other handle in a chain. There cases are possible when `Flush()` is triggered by an engine/whatever multiple times (not our case at least for now, so skipped). On `Flush()` is dispatched, gzip writer is returned back to the pool~

~Proper testing would require some injection either to a gzip's pool or some other level to observe how writers are retrieved and returned back.~

Ticket: https://trello.com/c/CbBmFu37/69-race-condition-in-remerge-gzip-causing-bidder-to-crash
